### PR TITLE
changed git repo from gitlab to github

### DIFF
--- a/archive/mkdocs.yml
+++ b/archive/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://open-regels.nl/
 
 # Repository
 repo_name: regels.overheid.nl
-repo_url: https://gitlab.com/discipl/RON/regels.overheid.nl
+repo_url: https://github.com/MinBZK/regels.overheid.nl
 
 # Hide the edit button
 edit_uri: edit/edited_via_edit_button/docs/
@@ -38,7 +38,7 @@ theme:
     - navigation.tracking
     - navigation.tabs
   icon:
-    repo: fontawesome/brands/gitlab
+    repo: fontawesome/brands/github
 
 markdown_extensions:
   - attr_list


### PR DESCRIPTION
Op live https://open-regels.nl/ stond nog de link naar gitlab. Dat is nu opgelost.

![image](https://user-images.githubusercontent.com/25812095/188198401-5cf2992f-9746-4407-b98c-426740619582.png)
