### PR TITLE
Disable SSG in favour of SSR

### DIFF
--- a/apps/web/src/pages/[[...slug]].tsx
+++ b/apps/web/src/pages/[[...slug]].tsx
@@ -1,6 +1,6 @@
 import { Typography } from '@mui/material';
 import { Box } from '@mui/system';
-import { GetStaticPaths, GetStaticProps } from 'next';
+import { GetServerSideProps } from 'next';
 import ReactMarkdown from 'react-markdown';
 import { PageService } from '../services/cms';
 
@@ -15,32 +15,16 @@ const Home: React.FC<Props> = ({ content }) => (
   </Box>
 );
 
-export const getStaticProps: GetStaticProps<Record<string, unknown>, { slug: string }> = async (ctx) => {
+export const getServerSideProps: GetServerSideProps<Record<string, unknown>, { slug: string }> = async (ctx) => {
   const { slug = 'home' } = ctx.params || {};
 
   const pageResponse = await PageService.getPagesSlugSlug(slug);
   const content = pageResponse.data?.attributes?.content || '';
 
-  console.log({ pageResponse });
-
   return {
     props: {
       content,
     },
-  };
-};
-
-export const getStaticPaths: GetStaticPaths = async () => {
-  const pagesResponse = await PageService.getPages();
-
-  const paths =
-    pagesResponse.data?.map((page) => ({
-      params: { slug: [page.attributes?.slug || ''] },
-    })) || [];
-
-  return {
-    paths,
-    fallback: true,
   };
 };
 


### PR DESCRIPTION
This pr temporarily disables SSG in favour of SSR. Until [on demand revalidation](https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration#on-demand-revalidation) has been implement the SSG should stay disabled.