### PR TITLE
Fix/rulespeak breaking method page

### DIFF
--- a/apps/web/src/pages/[[...slug]].tsx
+++ b/apps/web/src/pages/[[...slug]].tsx
@@ -12,7 +12,7 @@ interface Props {
 const Home: React.FC<Props> = ({ content, name }) => (
   <>
     <Head>
-      <title>Regelregister van de Nederlandse Overheid - {name}</title>
+      <title>{`Regelregister van de Nederlandse Overheid - ${name}`}</title>
     </Head>
     {/*  eslint-disable-next-line react/no-children-prop */}
     <ReactMarkdown children={content} components={{ p: Typography }} />

--- a/apps/web/src/pages/_document.tsx
+++ b/apps/web/src/pages/_document.tsx
@@ -7,7 +7,6 @@ export default function Document() {
         <link rel="icon" type="image/x-icon" href="/favicon.ico" />
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
         <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
-        <meta name="viewport" content="initial-scale=1, width=device-width" />
       </Head>
       <body>
         <Main />

--- a/apps/web/src/pages/methoden.tsx
+++ b/apps/web/src/pages/methoden.tsx
@@ -1,11 +1,18 @@
 import { Box, Card, CardContent, CardMedia, Stack, Typography } from '@mui/material';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
-import { getMethods, GetMethodsResponse } from '../services/strapi/get-methods';
+import { getMethods, GetMethodsResponse, Method } from '../services/strapi/get-methods';
 
 interface Props {
   methods: GetMethodsResponse;
 }
+
+const getMethodImage = (method: Method) => {
+  const preferred = method.attributes.Visual?.data?.attributes?.formats?.medium;
+  const fallback = method.attributes.Visual?.data?.attributes?.formats?.thumbnail;
+
+  return preferred || fallback;
+};
 
 const Methoden: React.FC<Props> = ({ methods }) => {
   return (
@@ -16,16 +23,18 @@ const Methoden: React.FC<Props> = ({ methods }) => {
       <Typography variant="h3">Methoden</Typography>
       <Box display="grid" gridTemplateColumns="repeat(3, 1fr)" columnGap={4} alignItems="flex-start">
         {methods.data?.map((method) => {
-          const mediaURL = `${process.env.NEXT_PUBLIC_CMS_ROOT_URL}${method.attributes.Visual?.data.attributes.formats.medium.url}`;
+          const image = getMethodImage(method);
 
           return (
             <Card key={method.id}>
-              <CardMedia
-                component="img"
-                height="300"
-                image={mediaURL.toString()}
-                alt={method.attributes.Visual?.data.attributes.formats.medium.name}
-              />
+              {image && (
+                <CardMedia
+                  component="img"
+                  height="300"
+                  image={`${process.env.NEXT_PUBLIC_CMS_ROOT_URL}${image.url}`}
+                  alt={image.name}
+                />
+              )}
               <CardContent>
                 <Typography gutterBottom variant="h5" component="div">
                   {method.attributes.Title}

--- a/apps/web/src/services/strapi/get-methods.ts
+++ b/apps/web/src/services/strapi/get-methods.ts
@@ -93,7 +93,7 @@ export interface Attributes {
   Visual?: Visual;
 }
 
-export interface Datum {
+export interface Method {
   id: number;
   attributes: Attributes;
 }
@@ -110,7 +110,7 @@ export interface Meta {
 }
 
 export interface GetMethodsResponse {
-  data: Datum[];
+  data: Method[];
   meta: Meta;
 }
 


### PR DESCRIPTION
resolves: #144 

Not all images that are uploaded to the cms have the same formats. This pr fixes it by preferring the medium format falling back onto the thumbnail format and if the thumbnail format is missing it will not render the image.

unrelated to the issue are the changes in `apps/web/src/pages/_document.tsx` and `apps/web/src/pages/[[...slug]].tsx` these were done to fix warnings/errors shown in the console. 