### PR TITLE
Fix: Broken path to `docs` in footer

### DIFF
--- a/apps/docs/docusaurus.config.js
+++ b/apps/docs/docusaurus.config.js
@@ -84,7 +84,7 @@ const config = {
             items: [
               {
                 label: 'Documentation',
-                to: '/docs/intro',
+                to: '/docs',
               },
             ],
           },


### PR DESCRIPTION
The current config shows a `Page not found` error as the path is wrong. Hence updated to the right Documentation path in the footer.