### PR TITLE
Roadmap page crashing on a client side route change

### DIFF
--- a/apps/web/src/pages/roadmap.tsx
+++ b/apps/web/src/pages/roadmap.tsx
@@ -7,6 +7,7 @@ import { GithubIcon } from '@/theme/icons/github-icon';
 import { LicenseIcon } from '@/theme/icons/license-icon';
 import { Stack, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { Box } from '@mui/system';
+import { GetServerSideProps } from 'next';
 import { useEffect, useRef, useState } from 'react';
 
 const Roadmap = () => {
@@ -78,6 +79,12 @@ const Roadmap = () => {
       </Stack>
     </Stack>
   );
+};
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return {
+    props: {},
+  };
 };
 
 export default Roadmap;


### PR DESCRIPTION
Fixes the issue that the roadmap page does not load when navigating. This is most likely a temporary fix as I don't know why this fix works.