### PR TITLE
Fix docs and about link in footer

### DIFF
--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -18,13 +18,13 @@ const linkGroups: ListItemLink[][] = [
     { title: 'Regelregister', href: 'https://regels.dexcat.nl/' },
   ],
   [
-    { title: 'Documentatie', href: '/docs' },
+    { title: 'Documentatie', href: 'https://regels.overheid.nl/docs' },
     { title: 'Privacy en cookies', href: '#' },
     { title: 'Toegankelijkheid', href: '#' },
     { title: 'Sitemap', href: '#' },
   ],
   [
-    { title: 'Methoden', href: ' https://regels.overheid.nl/methoden ' },
+    { title: 'Methoden', href: ' /methoden ' },
     { title: 'Overheid.nl', href: ' https://www.overheid.nl/' },
     { title: 'Linked Data Overheid', href: ' https://linkeddata.overheid.nl/front/portal/' },
     { title: 'PUC Open Data', href: ' https://puc.overheid.nl/mijno' },


### PR DESCRIPTION
resolves #233 

as @Abinashbunty mentioned links that go outside the NextJS application must start with https. Decided not to go with a solution that would allow for links that are outside the NextJS app but still on the same domain to start with `/` as for now it's a single use-case.