### PR TITLE
Disable standalone build

### DIFF
--- a/.changeset/six-fans-drive.md
+++ b/.changeset/six-fans-drive.md
@@ -1,0 +1,5 @@
+---
+'web': patch
+---
+
+Disabled standalone build

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -6,10 +6,6 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
-  output: 'standalone',
-  experimental: {
-    outputFileTracingRoot: path.join(__dirname, '../../'),
-  },
   webpack(config) {
     config.plugins.push(new webpack.IgnorePlugin({ resourceRegExp: /^pg-native$/ }));
 


### PR DESCRIPTION
Production is having some severe issues, this pr is a shot in the dark and disables the standalone build flag. It is hard to get to a real conclusive fix without shots in the dark as production builds that are being ran locally work perfectly fine. 