### PR TITLE
Rephrase sentence to remove "here" as link text

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@
 
 ## Introduction
 
-In 2021 Utrecht started developing the [Virtual Income Desk](https://opensource.pleio.nl/news/view/bc7443c1-483c-4aca-8a8f-16f2a954ff4f/het-virtueel-inkomstenloket) with Open Rules. An initiative with the aim for citizens to always and easily receive all financial regulations to which citizens are entitled.
+In 2021, Utrecht started developing the [Virtual Income Desk](https://opensource.pleio.nl/news/view/bc7443c1-483c-4aca-8a8f-16f2a954ff4f/het-virtueel-inkomstenloket) with Open Rules.
+This initiative aims for citizens to always and easily receive all financial regulations to which they are entitled.
 
-For the realization of this goal, standards of the [NORA guideline rule management](https://www.noraonline.nl/wiki/Leidraad_Regelbeheer) have been used. The publication of these standardized rules for the Virtual Income Desk have been published [here](https://regels.dexcat.nl/dataset/regelgroep-uit-te-keren-individuele-inkomenstoeslag).
+For the realization of this goal, standards of the [NORA guideline *rule management*](https://www.noraonline.nl/wiki/Leidraad_Regelbeheer) have been used.
+These standardized [rules for the Virtual Income Desk](https://regels.dexcat.nl/dataset/regelgroep-uit-te-keren-individuele-inkomenstoeslag) have now been published.
 
 Rules management is applied in various ways by organizations. A constant shared by all organizations is the need to implement the law according to the interpretation intended by the legislator, to act in accordance with the principles of good administration and to be able to adapt implementation as smoothly as possible to new insights from politics.
 


### PR DESCRIPTION
Links should have meaningful link texts for (greater) accessibility. "Click here" or "here" are not meaningful.

Also slightly rephrase the first sentences of the README for grammar improvements and add emphasis to "rule management" to stress that that is the name of the guideline.