### PR TITLE
Change conditions for deployment

### DIFF
--- a/.github/workflows/deploy-cms.yml
+++ b/.github/workflows/deploy-cms.yml
@@ -4,11 +4,8 @@ on:
     branches:
       - main
     paths:
-      - "apps/cms/**"
-      - ".github/actions/**"
-      - ".github/workflows/deploy-cms.yml"
-      - "package.json"
-      - "yarn.lock"
+      - 'apps/cms/CHANGELOG.md'
+      - '.github/workflows/deploy-cms.yml'
 jobs:
   build-cms-image:
     runs-on: ubuntu-latest
@@ -31,4 +28,3 @@ jobs:
           release-name: cms
           digitalocean-access-token: '${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}'
           cluster-id: '${{ secrets.DIGITALOCEAN_PRODUCTION_CLUSTER_ID }}'
-          

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,11 +4,8 @@ on:
     branches:
       - main
     paths:
-      - "apps/docs/**"
-      - ".github/actions/**"
-      - ".github/workflows/deploy-docs.yml"
-      - "package.json"
-      - "yarn.lock"
+      - 'apps/docs/CHANGELOG.md'
+      - '.github/workflows/deploy-docs.yml'
 jobs:
   build-docs-image:
     runs-on: ubuntu-latest
@@ -30,5 +27,3 @@ jobs:
           digitalocean-access-token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
           cluster-id: ${{ secrets.DIGITALOCEAN_PRODUCTION_CLUSTER_ID }}
           secrets: '${{ toJson(secrets) }}'
-
-

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -4,11 +4,8 @@ on:
     branches:
       - main
     paths:
-      - 'apps/web/**'
-      - '.github/actions/**'
+      - 'apps/web/CHANGELOG.md'
       - '.github/workflows/deploy-web.yml'
-      - 'package.json'
-      - 'yarn.lock'
 jobs:
   build-web-image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Changing conditions for deployment in order to only trigger a deployment when a GitHub release. GitHub releases are made by changesets, it's easier to detect which package has been released by only watching their associated `readme.md` files as these are only updated by changesets