### PR TITLE
Enable upload persistence

### DIFF
--- a/.github/configs/production/cms/values.yml
+++ b/.github/configs/production/cms/values.yml
@@ -12,4 +12,6 @@ ingress:
           pathType: Prefix
 imagePullSecrets:
   - name: regels-overheid-nl
+uploadsPersistence:
+  enabled: true
 configSecretName: cms-doppler-config


### PR DESCRIPTION
This is disabled in the default values, which means that the pvc will not be made. This PR overrides that default setting so the pvc will be created.