### PR TITLE
Remove typechecking step from validate pull request (web) workflow

### DIFF
--- a/.github/workflows/validate-web-pr.yml
+++ b/.github/workflows/validate-web-pr.yml
@@ -12,13 +12,6 @@ jobs:
         with:
           workspace: 'web'
           script: lint
-  typecheck:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: MinBZK/regels.overheid.nl/.github/actions/run-workspace-script@main
-        with:
-          workspace: 'web'
-          script: typecheck
   stylecheck:
     runs-on: ubuntu-20.04
     steps:
@@ -27,7 +20,7 @@ jobs:
           workspace: 'web'
           script: stylecheck
   build:
-    needs: [lint, typecheck, stylecheck]
+    needs: [lint, stylecheck]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Unlike typical TypeScript projects, Next.js requires the application to be built at least once before it can perform type checking. Considering this limitation, decision has been made to remove the typechecking step from our GitHub Actions for the web workflow. More on this can be read [here](https://github.com/vercel/next.js/issues/53959)