### PR TITLE
Publication pages not showing 404 page when publication doesn't exist 

### DIFF
--- a/.changeset/shaggy-cups-join.md
+++ b/.changeset/shaggy-cups-join.md
@@ -1,0 +1,5 @@
+---
+'web': patch
+---
+
+404 page not showing when navigating to a publication that doesn't exist

--- a/apps/web/src/app/(common-page)/publicaties/[...slug]/route.ts
+++ b/apps/web/src/app/(common-page)/publicaties/[...slug]/route.ts
@@ -1,5 +1,4 @@
 import fs from 'fs/promises';
-import { notFound } from 'next/navigation';
 
 export async function GET(request: Request) {
   const enhancedUrl = new URL(request.url);
@@ -13,7 +12,12 @@ export async function GET(request: Request) {
     .then(() => true)
     .catch(() => false);
 
-  if (!publicationExists) notFound();
+  if (!publicationExists) {
+    const url = new URL('/404', request.url);
+    const response = await fetch(url.toString());
+
+    return new Response(response.body);
+  }
 
   const buffer = await fs.readFile(publicationPath);
 


### PR DESCRIPTION
resolved: #408 

The `notFound` doesn't seem to be doing anything in [route handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) so now a fix has been made where the 404 gets fetched and the user can continue in using the website as normal