### PR TITLE
Fix/url legitimaat publicatie

### DIFF
--- a/.changeset/big-hairs-end.md
+++ b/.changeset/big-hairs-end.md
@@ -1,0 +1,5 @@
+---
+'web': patch
+---
+
+Updated legitimaat url with new publication (moved from open-regels.nl)

--- a/apps/web/src/app/(common-page)/publicaties/page.tsx
+++ b/apps/web/src/app/(common-page)/publicaties/page.tsx
@@ -15,7 +15,7 @@ export default function PublicatiesPage() {
         <PublicationCard
           tag="Algoritme"
           title="De Legitimaat"
-          url="/publicaties/de-legitimaat"
+          url="/publicaties/legitimaat"
           description="Een werkmethode voor het doen van onderzoek door derden naar het gebruik van algoritmen door een overheidsorganisatie."
         />
         <PublicationCard


### PR DESCRIPTION
Config was still open-regels.nl. Fixed that ánd build brand new repo with publish.yml.